### PR TITLE
Compatibility with Chat Heads

### DIFF
--- a/src/main/java/ninjaphenix/aofemotes/mixin/ChatHudMixin.java
+++ b/src/main/java/ninjaphenix/aofemotes/mixin/ChatHudMixin.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 
 import java.util.List;
 
-@Mixin({ChatHud.class})
+@Mixin(value = {ChatHud.class}, priority = 1010)
 public abstract class ChatHudMixin {
     @Redirect(
             method = {"render"},


### PR DESCRIPTION
Hey, apparently there is a [Mixin conflict](https://github.com/dzwdz/chat_heads/issues/26) with this mod's [`ChatHudMixin`](https://github.com/Ellemes/aof-emotes/blob/069db083ffc0d37a54659c82754fbd158c70be94/src/main/java/ninjaphenix/aofemotes/mixin/ChatHudMixin.java) and Chat Heads' [`ChatComponentMixin`](https://github.com/dzwdz/chat_heads/blob/eba310c502d0d177f8a06fce0b38d06925f18ee3/common/src/main/java/dzwdz/chat_heads/mixin/ChatComponentMixin.java) (same class, different mappings), which moves the text a bit.

The issue is that Chat Head targets the `TextRenderer.drawWithShadow` call (via a [`@ModifyArg`](https://github.com/dzwdz/chat_heads/blob/architectury-1.18.x/common/src/main/java/dzwdz/chat_heads/mixin/ChatComponentMixin.java#L36-L39)) which this mod redirects, so Mixin doesn't know what to do.

Originally I wrote a bit of a more [complicated/ugly solution](https://github.com/Fourmisain/aof-emotes/commit/119cdbf55d19d056781fa31f0501326d3b8ab93b), which turns the `@Redirect` into a `@ModifyArgs` which is compatible with the `@ModifyArg`. Adjusting the mixin priority helped the consistency (emotes not being moved with the text) due to Mixin load order.

Then I wondered if it's not enough to only adjust the priority and well, looks like it is, so here you go! :sweat_smile: