### PR TITLE
Update to support 1.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.11-SNAPSHOT'
+	id 'fabric-loom' version '0.12.1'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.18.1
-	yarn_mappings=1.18.1+build.22
-	loader_version=0.12.12
+	minecraft_version=1.19
+	yarn_mappings=1.19+build.4
+	loader_version=0.14.7
 
 # Mod Properties
 	mod_version = 0.0.4
@@ -13,4 +13,4 @@ org.gradle.jvmargs=-Xmx1G
 	archives_base_name = aofemotes
 
 # Dependencies
-	fabric_version=0.46.2+1.18
+	fabric_version=0.56.1+1.19

--- a/src/main/java/ninjaphenix/aofemotes/emotes/Emote.java
+++ b/src/main/java/ninjaphenix/aofemotes/emotes/Emote.java
@@ -7,6 +7,7 @@ import net.minecraft.util.Identifier;
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.util.Optional;
 
 public final class Emote {
     private final int id;
@@ -22,7 +23,9 @@ public final class Emote {
         this.name = name;
         this.filePath = filePath;
         this.frameTimeMs = frameTimeMs;
-        try (Resource resource = MinecraftClient.getInstance().getResourceManager().getResource(filePath)) {
+        Optional<Resource> optRecource = MinecraftClient.getInstance().getResourceManager().getResource(filePath);
+        if(optRecource.isPresent()) {
+            Resource resource = optRecource.get();
             BufferedImage bufferedImage = ImageIO.read(resource.getInputStream());
             if (bufferedImage == null) {
                 throw new IOException("Failed to load image: " + filePath);
@@ -37,6 +40,12 @@ public final class Emote {
                 height = bufferedImage.getHeight();
             }
         }
+        else{
+            width = 0;
+            height = 0;
+            frameCount = -1;
+        }
+
 
     }
 

--- a/src/main/java/ninjaphenix/aofemotes/text/TextReaderVisitor.java
+++ b/src/main/java/ninjaphenix/aofemotes/text/TextReaderVisitor.java
@@ -1,9 +1,10 @@
 package ninjaphenix.aofemotes.text;
 
 import net.minecraft.text.CharacterVisitor;
-import net.minecraft.text.LiteralText;
 import net.minecraft.text.OrderedText;
+import net.minecraft.text.Text;
 import net.minecraft.text.Style;
+import net.minecraft.text.MutableText;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,9 +36,9 @@ public class TextReaderVisitor implements CharacterVisitor {
     }
 
     public OrderedText getOrderedText() {
-        LiteralText literalText = new LiteralText("");
+        MutableText literalText = MutableText.of(Text.of("").getContent());
         for (TextPart textPart : textParts) {
-            literalText.append(new LiteralText(Character.toString(textPart.getChar())).setStyle(textPart.getStyle()));
+            literalText.append(MutableText.of(Text.of(Character.toString(textPart.getChar())).getContent()).setStyle(textPart.getStyle()));
         }
         return literalText.asOrderedText();
     }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,9 +23,9 @@
     "aofemotes.mixins.json"
   ],
   "depends": {
-    "fabricloader": "*",
-    "fabric-resource-loader-v0": ">=0.4.12",
-    "minecraft": "~1.18.1",
+    "fabricloader": ">=0.14.7",
+    "fabric-resource-loader-v0": ">=0.5",
+    "minecraft": "~1.19",
     "java": ">=17"
   },
   "breaks": {


### PR DESCRIPTION
Libraries:
-Updated to Loom 0.12.1
-Updated to Minecraft 1.19
-Updated to Yarn Mappings 1.19+build.4
-Updated to Loader 0.14.7 or higher
-Updated to Fabric Version 0.56.1+1.19

Emote.java:

Resource Problem:
-ResourceManager.getResource(path) no longer returns Resource, but Optional<Resource>
-It seems Resource nor Optional<Resource> are autoclosable anymore with try resource with Minecraft 1.19.

Solution: It may be temporary until a new try resource solution is found, but a current if-else solution using Option's isPresent() works in my testing on Fabric 0.14.8

TextReaderVisitor.java:

LiteralText has been removed with 1.19. This new solution replaces LiteralText's old usage with the new Text and MutableText classes. Has identical functionality to old solution.